### PR TITLE
[REFACTOR] union_*: change affiliate uid from Char to Integer

### DIFF
--- a/import_tests/README.md
+++ b/import_tests/README.md
@@ -49,9 +49,9 @@ El mensaje de error depende del estado del flag:
   *"Affiliate does not exist in the database (UID: …)"* — los chequeos de
   dígito/cero viven dentro de la rama de auto-creación.
 - **Flag ON**: se llega a las validaciones específicas —
-  *"El campo ID debe contener únicamente números."* y
-  *"El campo ID no puede comenzar con cero."*
-- **Contributions**: la validación de dígitos es **incondicional** (ver bug
+  *"El campo ID debe contener un número entero válido."* y
+  *"El campo ID debe ser un número positivo."*
+- **Contributions**: la validación de uid es **incondicional** (ver nota
   en §5), así que el mensaje específico aparece con el flag en cualquier estado.
 
 ## 3. Qué ejercita cada diseño de columna
@@ -89,19 +89,15 @@ Verificar además que propagaron `personal_id`/`vat` cuando el CSV los trae.
   `<Afiliado>,<fecha>`.
 - Página **Aportes** del afiliado muestra los nuevos registros (orden fecha desc).
 
-## 5. ⚠️ Bug conocido detectado al diseñar estos CSVs
+## 5. ~~Bug conocido~~ — FIXED
 
-`contribution.affiliate_contribution._prepare_import_vals()` valida
-`import_uid.isdigit()` **antes** de los fallbacks por
-`import_personal_id` / `import_vat` / `import_name`. Consecuencia:
+`contribution.affiliate_contribution._prepare_import_vals()` ahora valida
+`import_uid` sólo dentro de la rama `if import_uid:`, permitiendo que los
+fallbacks por `import_personal_id` / `import_vat` / `import_name` funcionen
+cuando el uid no está presente.
 
-- Una fila SIN `import_uid` (aunque traiga un `import_personal_id` válido)
-  siempre lanza *"El campo ID debe contener únicamente números."* — los
-  fallbacks de búsqueda son código muerto hoy.
-- Por eso TODAS las filas de aportes de estos CSVs incluyen `import_uid`.
-
-Fix sugerido (pendiente): mover la validación dentro de la rama que usa el
-uid (búsqueda + auto-creación) y validar `import_uid` sólo si está presente.
+El uid se validó de `Char` a `Integer` en todo el stack (ver commit
+`[REFACTOR] union_*: change affiliate uid from Char to Integer`).
 
 ## 6. Limpieza
 

--- a/union_affiliation/__manifest__.py
+++ b/union_affiliation/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "Mueve",
     "website": "https://mueve.org.ar/",
     "category": "Union",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.2.0",
     "license": "AGPL-3",
     "depends": ["base", "mail"],
     "data": [

--- a/union_affiliation/migrations/19.0.1.2.0/pre-migrate.py
+++ b/union_affiliation/migrations/19.0.1.2.0/pre-migrate.py
@@ -1,4 +1,4 @@
-def migrate(cr, version):
+def migrate(cr, _version):
     """uid field type changed from Char to Integer.
 
     Odoo's _auto_init handles the column type change
@@ -13,7 +13,7 @@ def migrate(cr, version):
     cr.execute("SELECT count(*) FROM affiliation_affiliate WHERE uid !~ '^[0-9]+$'")
     non_numeric = cr.fetchone()[0]
     if non_numeric:
-        raise Exception(
+        raise ValueError(
             f"Found {non_numeric} affiliate(s) with non-numeric uid. "
             "Fix them before upgrading (the uid column is changing from "
             "varchar to integer)."

--- a/union_affiliation/migrations/19.0.1.2.0/pre-migrate.py
+++ b/union_affiliation/migrations/19.0.1.2.0/pre-migrate.py
@@ -1,0 +1,20 @@
+def migrate(cr, version):
+    """uid field type changed from Char to Integer.
+
+    Odoo's _auto_init handles the column type change
+    (ALTER TABLE ... ALTER COLUMN uid TYPE int4 USING uid::int4).
+    All existing values are guaranteed numeric by the previous
+    isdigit() constraint, so the cast is safe.
+
+    This script validates the precondition and aborts early if
+    non-numeric data is found, giving a clear error instead of
+    a cryptic PostgreSQL cast failure.
+    """
+    cr.execute("SELECT count(*) FROM affiliation_affiliate WHERE uid !~ '^[0-9]+$'")
+    non_numeric = cr.fetchone()[0]
+    if non_numeric:
+        raise Exception(
+            f"Found {non_numeric} affiliate(s) with non-numeric uid. "
+            "Fix them before upgrading (the uid column is changing from "
+            "varchar to integer)."
+        )

--- a/union_affiliation/models/affiliate.py
+++ b/union_affiliation/models/affiliate.py
@@ -19,13 +19,17 @@ class Affiliate(models.Model):
         "unique(uid)",
         "There is already exist an affiliated with the same affiliate UID!",
     )
+    _uid_positive = models.Constraint(
+        "CHECK (uid > 0)",
+        "The affiliate UID must be a positive number.",
+    )
     _unique_affiliation_number = models.Constraint(
         "unique(affiliation_number)",
         "There is already exist an affiliated with the same affiliation number!",
     )
 
     partner_id = fields.Many2one(comodel_name="res.partner", string="Partner", ondelete="cascade", required=True)
-    uid = fields.Char(string="Affiliate UID", required=True, index=True)
+    uid = fields.Integer(string="Affiliate UID", required=True, index=True)
     work_id = fields.Char(string="Work ID")
     personal_id_type = fields.Selection(
         [
@@ -141,16 +145,6 @@ class Affiliate(models.Model):
         column2="category_id",
         string="Etiqueta BIS",
     )
-
-    @api.constrains("uid")
-    def _check_uid(self):
-        for record in self:
-            if not record.uid:
-                raise ValidationError(_("The affiliate UID is required."))
-            if not record.uid.isdigit():
-                raise ValidationError(_("El campo ID debe contener únicamente números."))
-            if record.uid[0] == "0":
-                raise ValidationError(_("El campo ID no puede comenzar con cero."))
 
     @api.constrains("state", "affiliate_type_id")
     def _check_affiliate_type_id(self):
@@ -396,12 +390,11 @@ class Affiliate(models.Model):
         if name:
             domain = [
                 "|",
-                "|",
                 ("personal_id", operator, name),
-                ("uid", operator, name),
                 ("name", operator, name),
             ]
-            # Buscar directamente con el dominio personalizado
+            if name.isdigit():
+                domain = ["|", ("uid", "=", int(name))] + domain
             return self._search(args + domain, limit=limit)
         return super()._name_search(name, args, operator, limit)
 

--- a/union_affiliation/tests/test_affiliate.py
+++ b/union_affiliation/tests/test_affiliate.py
@@ -14,7 +14,7 @@ class TestAffiliate(TransactionCase):
         cls.Affiliate = cls.env["affiliation.affiliate"]
         cls.affiliate_type = cls.env["affiliation.affiliate_type"].create({"name": "Test Type", "enabled": True})
 
-    def _create_affiliate(self, uid="12345678", name="Test Affiliate", **kw):
+    def _create_affiliate(self, uid=12345678, name="Test Affiliate", **kw):
         vals = {"uid": uid, "name": name, "state": "new"}
         vals.update(kw)
         return self.Affiliate.sudo().create(vals)
@@ -23,47 +23,42 @@ class TestAffiliate(TransactionCase):
 
     def test_uid_unique_constraint(self):
         """models.Constraint uid_unique prevents duplicate uid."""
-        self._create_affiliate(uid="11111111")
+        self._create_affiliate(uid=11111111)
         with self.assertRaises(UniqueViolation):
             with self.env.cr.savepoint():
-                self._create_affiliate(uid="11111111", name="Other")
+                self._create_affiliate(uid=11111111, name="Other")
 
     def test_affiliation_number_unique_constraint(self):
         """models.Constraint unique_affiliation_number prevents duplicates."""
-        aff1 = self._create_affiliate(uid="22222222")
+        aff1 = self._create_affiliate(uid=22222222)
         aff1.write({"affiliation_number": 1001})
-        aff2 = self._create_affiliate(uid="33333333")
+        aff2 = self._create_affiliate(uid=33333333)
         with self.assertRaises(UniqueViolation):
             with self.env.cr.savepoint():
                 aff2.write({"affiliation_number": 1001})
 
-    # ─── _check_uid Python constraint ─────────────────────────────────────────
+    # ─── uid positive constraint (SQL CHECK uid > 0) ─────────────────────────
 
-    def test_uid_must_be_digits(self):
-        """uid containing non-digit characters raises ValidationError."""
-        with self.assertRaises(ValidationError):
-            self._create_affiliate(uid="12A45678")
+    def test_uid_must_be_positive(self):
+        """uid=0 must be rejected by the CHECK (uid > 0) constraint."""
+        with self.assertRaises(Exception):
+            self._create_affiliate(uid=0)
 
-    def test_uid_cannot_start_with_zero(self):
-        """uid starting with '0' raises ValidationError."""
-        with self.assertRaises(ValidationError):
-            self._create_affiliate(uid="01234567")
-
-    def test_uid_valid_all_digits(self):
-        """uid with all digits and non-zero start is accepted."""
-        aff = self._create_affiliate(uid="98765432")
-        self.assertEqual(aff.uid, "98765432")
+    def test_uid_valid_positive(self):
+        """uid with a positive value is accepted."""
+        aff = self._create_affiliate(uid=98765432)
+        self.assertEqual(aff.uid, 98765432)
 
     # ─── _check_affiliate_type_id constraint ──────────────────────────────────
 
     def test_affiliate_type_required_for_non_new_states(self):
         """affiliate_type_id is required when state is not 'new' or 'not_affiliated'."""
         with self.assertRaises(ValidationError):
-            self._create_affiliate(uid="44444444", state="affiliated")
+            self._create_affiliate(uid=44444444, state="affiliated")
 
     def test_affiliate_type_not_required_for_new(self):
         """state 'new' does not require affiliate_type_id."""
-        aff = self._create_affiliate(uid="55555555", state="new")
+        aff = self._create_affiliate(uid=55555555, state="new")
         self.assertEqual(aff.state, "new")
 
     # ─── seniority_years compute ──────────────────────────────────────────────
@@ -72,32 +67,32 @@ class TestAffiliate(TransactionCase):
         """seniority_years computes years from seniority date to today."""
         from datetime import date
 
-        aff = self._create_affiliate(uid="66666666")
+        aff = self._create_affiliate(uid=66666666)
         aff.write({"seniority": date(2020, 1, 1)})
         self.assertGreaterEqual(aff.seniority_years, 4)
 
     def test_seniority_years_zero_when_no_seniority(self):
         """seniority_years is 0 when seniority date is not set."""
-        aff = self._create_affiliate(uid="77777777")
+        aff = self._create_affiliate(uid=77777777)
         self.assertEqual(aff.seniority_years, 0)
 
     # ─── _name_search override ────────────────────────────────────────────────
 
     def test_name_search_by_uid(self):
-        """_name_search finds affiliates by uid."""
-        self._create_affiliate(uid="88888888", name="John Doe")
+        """_name_search finds affiliates by uid (integer equality)."""
+        self._create_affiliate(uid=88888888, name="John Doe")
         results = self.Affiliate.sudo()._name_search("88888888")
         self.assertTrue(results, "Should find affiliate by uid")
 
     def test_name_search_by_personal_id(self):
         """_name_search finds affiliates by personal_id."""
-        self._create_affiliate(uid="99999999", name="Jane Roe", personal_id="12345")
+        self._create_affiliate(uid=99999999, name="Jane Roe", personal_id="12345")
         results = self.Affiliate.sudo()._name_search("12345")
         self.assertTrue(results, "Should find affiliate by personal_id")
 
     def test_name_search_by_name(self):
         """_name_search finds affiliates by name."""
-        self._create_affiliate(uid="10101010", name="Unique Search Name")
+        self._create_affiliate(uid=10101010, name="Unique Search Name")
         results = self.Affiliate.sudo()._name_search("Unique Search")
         self.assertTrue(results, "Should find affiliate by name")
 
@@ -121,18 +116,7 @@ class TestAffiliate(TransactionCase):
         indexes = [r[0] for r in self.env.cr.fetchall()]
         self.assertTrue(any("uid" in i for i in indexes))
 
-    # ─── _check_uid edge cases (P0 regression) ────────────────────────────────
-
-    def test_uid_empty_string_raises_validation_error(self):
-        """Writing an empty uid must raise ValidationError, not IndexError.
-
-        Regression: `record.uid[0] == '0'` ran before any falsy guard and
-        crashed with IndexError on '' (empty string bypasses the NOT NULL
-        column check because it is not NULL).
-        """
-        aff = self._create_affiliate(uid="70777001")
-        with self.assertRaises(ValidationError):
-            aff.write({"uid": ""})
+    # ─── batch create (P0 regression) ────────────────────────────────────────
 
     def test_batch_create_types_does_not_crash(self):
         """Batch create of affiliate types must not hit ExpectedSingleton.

--- a/union_affiliation/tests/test_affiliation_period.py
+++ b/union_affiliation/tests/test_affiliation_period.py
@@ -27,7 +27,7 @@ class TestAffiliationPeriod(TransactionCase):
         Regression: old _check_from_date/_check_to_date only matched
         endpoint-inside ranges, so [Feb-Mar] + [Jan-Dec] coexisted.
         """
-        aff = self._make_affiliate("70888001")
+        aff = self._make_affiliate(70888001)
         self.Period.create(
             {
                 "affiliate_id": aff.id,
@@ -49,7 +49,7 @@ class TestAffiliationPeriod(TransactionCase):
 
     def test_open_period_overlaps_any_later_period(self):
         """A still-open period (no to_date) blocks any overlapping new one."""
-        aff = self._make_affiliate("70888002")
+        aff = self._make_affiliate(70888002)
         self.Period.create(
             {
                 "affiliate_id": aff.id,
@@ -70,7 +70,7 @@ class TestAffiliationPeriod(TransactionCase):
 
     def test_non_overlapping_periods_allowed(self):
         """Back-to-back periods (end == next start) are valid."""
-        aff = self._make_affiliate("70888003")
+        aff = self._make_affiliate(70888003)
         self.Period.create(
             {
                 "affiliate_id": aff.id,
@@ -93,7 +93,7 @@ class TestAffiliationPeriod(TransactionCase):
 
     def test_batch_create_closed_periods_does_not_crash(self):
         """Batch create must not hit ExpectedSingleton in constrains."""
-        aff = self._make_affiliate("70888004")
+        aff = self._make_affiliate(70888004)
         records = self.Period.create(
             [
                 {
@@ -116,8 +116,8 @@ class TestAffiliationPeriod(TransactionCase):
 
     def test_duplicate_affiliation_number_raises_validation_error(self):
         """Duplicate numbers raise ValidationError even in a batch create."""
-        aff = self._make_affiliate("70888005")
-        other = self._make_affiliate("70888006")
+        aff = self._make_affiliate(70888005)
+        other = self._make_affiliate(70888006)
         self.Period.create(
             {
                 "affiliate_id": aff.id,
@@ -146,7 +146,7 @@ class TestAffiliationPeriod(TransactionCase):
 
     def test_dates_order_validation_error(self):
         """from_date >= to_date raises ValidationError (singleton-safe)."""
-        aff = self._make_affiliate("70888007")
+        aff = self._make_affiliate(70888007)
         with self.assertRaises(ValidationError):
             self.Period.create(
                 {

--- a/union_affiliation/tests/test_security.py
+++ b/union_affiliation/tests/test_security.py
@@ -48,10 +48,10 @@ class TestAffiliationSecurity(TransactionCase):
             wp.with_user(self.user_internal).write({"name": "X"})
 
     def test_affiliation_read_user_can_read(self):
-        aff = self.Affiliate.sudo().create({"uid": "12121212", "name": "Sec Aff R", "state": "new"})
+        aff = self.Affiliate.sudo().create({"uid": 12121212, "name": "Sec Aff R", "state": "new"})
         aff.with_user(self.user_aff_read).read(["name"])
 
     def test_affiliation_write_user_cannot_delete(self):
-        aff = self.Affiliate.sudo().create({"uid": "34343434", "name": "Sec Aff Del", "state": "new"})
+        aff = self.Affiliate.sudo().create({"uid": 34343434, "name": "Sec Aff Del", "state": "new"})
         with self.assertRaises(AccessError):
             aff.with_user(self.user_aff_write).unlink()

--- a/union_affiliation/tests/test_security.py
+++ b/union_affiliation/tests/test_security.py
@@ -1,7 +1,9 @@
 from odoo.exceptions import AccessError
 from odoo.tests import TransactionCase, tagged
 
-grp = lambda env, x: env.ref(x).id
+
+def grp(env, x):
+    return env.ref(x).id
 
 
 @tagged("post_install", "security", "union")

--- a/union_affiliation/views/affiliate_views.xml
+++ b/union_affiliation/views/affiliate_views.xml
@@ -143,7 +143,7 @@
             <field name="arch" type="xml">
                 <search string="Affiliate filters">
                     <field name="name" filter_domain="[('name', 'ilike', self)]" />
-                    <field name="uid" filter_domain="[('uid', 'ilike', self)]" />
+                    <field name="uid" />
                     <field name="personal_id" filter_domain="[('personal_id', 'ilike', self)]" />
                     <field name="category_bis_id"
                         filter_domain="[('category_bis_id', 'ilike', self)]" />

--- a/union_benefit_request/models/benefit_request.py
+++ b/union_benefit_request/models/benefit_request.py
@@ -170,8 +170,8 @@ class BenefitRequest(models.Model):
                 if "import_uid" in vals:
                     try:
                         uid_int = int(vals["import_uid"])
-                    except (TypeError, ValueError):
-                        raise ValidationError(_("El campo ID debe contener un número entero válido."))
+                    except (TypeError, ValueError) as exc:
+                        raise ValidationError(_("El campo ID debe contener un número entero válido.")) from exc
                     affiliate = self.env["affiliation.affiliate"].search([("uid", "=", uid_int)])
                     if len(affiliate.ids):
                         affiliate = affiliate[0]

--- a/union_benefit_request/models/benefit_request.py
+++ b/union_benefit_request/models/benefit_request.py
@@ -24,7 +24,7 @@ class BenefitRequest(models.Model):
         tracking=True,
     )
     # The next two fields only will be used to filters
-    affiliate_uid = fields.Char(string="Affiliate UID", compute="_compute_uid", store=True)
+    affiliate_uid = fields.Integer(string="Affiliate UID", compute="_compute_uid", store=True)
     affiliate_personal_id = fields.Char(string="Personal ID", compute="_compute_personal_id", store=True)
 
     # Field for import process - maps to affiliate by UID
@@ -168,16 +168,19 @@ class BenefitRequest(models.Model):
         if "import_file" in self.env.context:
             for vals in vals_list:
                 if "import_uid" in vals:
-                    affiliate = self.env["affiliation.affiliate"].search([("uid", "=", vals["import_uid"])])
+                    try:
+                        uid_int = int(vals["import_uid"])
+                    except (TypeError, ValueError):
+                        raise ValidationError(_("El campo ID debe contener un número entero válido."))
+                    affiliate = self.env["affiliation.affiliate"].search([("uid", "=", uid_int)])
                     if len(affiliate.ids):
                         affiliate = affiliate[0]
                     else:
                         conf = self.env["affiliation.affiliation_configuration"].browse(1)
                         if conf.create_user_from_request:
-                            new_uid = vals.get("import_uid")
                             import_name = vals.get("import_name")
 
-                            if not new_uid or not import_name:
+                            if not import_name:
                                 error_msg = _(
                                     "Cannot create affiliate for request import."
                                     " Missing import_name or ID (import_uid)."
@@ -185,13 +188,11 @@ class BenefitRequest(models.Model):
                                     " affiliate Name and ID."
                                 )
                                 raise ValidationError(error_msg)
-                            if not str(new_uid).isdigit():
-                                raise ValidationError(_("El campo ID debe contener únicamente números."))
-                            if str(new_uid)[0] == "0":
-                                raise ValidationError(_("El campo ID no puede comenzar con cero."))
+                            if uid_int <= 0:
+                                raise ValidationError(_("El campo ID debe ser un número positivo."))
 
                             new_affiliate_data = {
-                                "uid": new_uid,
+                                "uid": uid_int,
                                 "name": import_name,
                                 "state": "new",
                             }

--- a/union_benefit_request/tests/test_benefit_request.py
+++ b/union_benefit_request/tests/test_benefit_request.py
@@ -147,7 +147,7 @@ class TestBenefitRequest(TransactionCase):
         affiliate = (
             self.env["affiliation.affiliate"]
             .sudo()
-            .create({"uid": "50000001", "name": "Import Test Affiliate", "state": "new"})
+            .create({"uid": 50000001, "name": "Import Test Affiliate", "state": "new"})
         )
         req = (
             self.BenefitRequest.sudo()

--- a/union_benefit_request/tests/test_security.py
+++ b/union_benefit_request/tests/test_security.py
@@ -1,7 +1,9 @@
 from odoo.exceptions import AccessError
 from odoo.tests import TransactionCase, tagged
 
-grp = lambda env, x: env.ref(x).id
+
+def grp(env, x):
+    return env.ref(x).id
 
 
 @tagged("post_install", "security", "union")

--- a/union_contribution/models/contribution.py
+++ b/union_contribution/models/contribution.py
@@ -64,13 +64,6 @@ class AffiliateContribution(models.Model):
         Expected import keys are: import_uid, import_name, import_vat, import_personal_id.
         """
         import_uid = vals.get("import_uid")
-        try:
-            uid_int = int(import_uid)
-        except (TypeError, ValueError):
-            raise ValidationError(_("El campo ID debe contener un número entero válido."))
-        if uid_int <= 0:
-            raise ValidationError(_("El campo ID debe ser un número positivo."))
-
         import_name = vals.get("import_name")
         import_vat = vals.get("import_vat")
         import_personal_id = vals.get("import_personal_id")
@@ -83,7 +76,14 @@ class AffiliateContribution(models.Model):
         affiliate_model = self.env["affiliation.affiliate"]
         affiliate = affiliate_model.browse()
 
+        uid_int = None
         if import_uid:
+            try:
+                uid_int = int(import_uid)
+            except (TypeError, ValueError):
+                raise ValidationError(_("El campo ID debe contener un número entero válido."))
+            if uid_int <= 0:
+                raise ValidationError(_("El campo ID debe ser un número positivo."))
             affiliate = affiliate_model.search([("uid", "=", uid_int)], limit=1)
 
         if not affiliate and import_personal_id:

--- a/union_contribution/models/contribution.py
+++ b/union_contribution/models/contribution.py
@@ -80,8 +80,8 @@ class AffiliateContribution(models.Model):
         if import_uid:
             try:
                 uid_int = int(import_uid)
-            except (TypeError, ValueError):
-                raise ValidationError(_("El campo ID debe contener un número entero válido."))
+            except (TypeError, ValueError) as exc:
+                raise ValidationError(_("El campo ID debe contener un número entero válido.")) from exc
             if uid_int <= 0:
                 raise ValidationError(_("El campo ID debe ser un número positivo."))
             affiliate = affiliate_model.search([("uid", "=", uid_int)], limit=1)

--- a/union_contribution/models/contribution.py
+++ b/union_contribution/models/contribution.py
@@ -31,7 +31,7 @@ class AffiliateContribution(models.Model):
     import_vat = fields.Char(string="Import vat")
     import_personal_id = fields.Char(string="Import personal ID")
 
-    uid = fields.Char(related="affiliate_id.uid", store=False)
+    uid = fields.Integer(related="affiliate_id.uid", store=False)
     personal_id = fields.Char(related="affiliate_id.personal_id", store=False)
 
     @api.model_create_multi
@@ -64,10 +64,12 @@ class AffiliateContribution(models.Model):
         Expected import keys are: import_uid, import_name, import_vat, import_personal_id.
         """
         import_uid = vals.get("import_uid")
-        if not str(import_uid).isdigit():
-            raise ValidationError(_("El campo ID debe contener únicamente números."))
-        if str(import_uid)[0] == "0":
-            raise ValidationError(_("El campo ID no puede comenzar con cero."))
+        try:
+            uid_int = int(import_uid)
+        except (TypeError, ValueError):
+            raise ValidationError(_("El campo ID debe contener un número entero válido."))
+        if uid_int <= 0:
+            raise ValidationError(_("El campo ID debe ser un número positivo."))
 
         import_name = vals.get("import_name")
         import_vat = vals.get("import_vat")
@@ -82,7 +84,7 @@ class AffiliateContribution(models.Model):
         affiliate = affiliate_model.browse()
 
         if import_uid:
-            affiliate = affiliate_model.search([("uid", "=", import_uid)], limit=1)
+            affiliate = affiliate_model.search([("uid", "=", uid_int)], limit=1)
 
         if not affiliate and import_personal_id:
             affiliate = affiliate_model.search([("personal_id", "=", import_personal_id)], limit=1)
@@ -111,9 +113,9 @@ class AffiliateContribution(models.Model):
                 )
 
             affiliate_vals = {
-                "uid": import_uid,
+                "uid": uid_int,
                 "state": "new",
-                "name": import_name or import_uid,
+                "name": import_name or str(uid_int),
             }
             if import_vat:
                 affiliate_vals["vat"] = import_vat

--- a/union_contribution/tests/test_contribution.py
+++ b/union_contribution/tests/test_contribution.py
@@ -17,7 +17,7 @@ class TestContribution(TransactionCase):
             .sudo()
             .create(
                 {
-                    "uid": "70000001",
+                    "uid": 70000001,
                     "name": "Contribution Test Affiliate",
                     "state": "new",
                 }
@@ -143,7 +143,7 @@ class TestInconsistenciesResult(TransactionCase):
             .sudo()
             .create(
                 {
-                    "uid": "80000001",
+                    "uid": 80000001,
                     "name": "Inconsistency Test Affiliate",
                     "state": "affiliated",
                     "quote": False,

--- a/union_contribution/tests/test_security.py
+++ b/union_contribution/tests/test_security.py
@@ -16,7 +16,7 @@ class TestContributionSecurity(TransactionCase):
         cls.affiliate_type = cls.env["affiliation.affiliate_type"].create({"name": "Sec CType", "enabled": True})
         cls.aff = cls.Affiliate.sudo().create(
             {
-                "uid": "22222222",
+                "uid": 22222222,
                 "name": "Sec Aff Q",
                 "state": "affiliated",
                 "affiliate_type_id": cls.affiliate_type.id,

--- a/union_contribution/tests/test_security.py
+++ b/union_contribution/tests/test_security.py
@@ -1,7 +1,9 @@
 from odoo.exceptions import UserError
 from odoo.tests import TransactionCase, tagged
 
-grp = lambda env, x: env.ref(x).id
+
+def grp(env, x):
+    return env.ref(x).id
 
 
 @tagged("post_install", "security", "union")

--- a/union_contribution/views/contribution_views.xml
+++ b/union_contribution/views/contribution_views.xml
@@ -46,7 +46,7 @@
             <field name="arch" type="xml">
                 <search string="Contribution filters">
                     <field name="affiliate_id"
-                        filter_domain="['|','|',('affiliate_id.name', 'ilike', self),('affiliate_id.uid', 'ilike', self),('affiliate_id.personal_id', 'ilike', self)]" />
+                        filter_domain="['|','|',('affiliate_id.name', 'ilike', self),('affiliate_id.uid', '=', self),('affiliate_id.personal_id', 'ilike', self)]" />
                     <field name="contribution_code_id"
                         filter_domain="['|',('contribution_code_id.description', 'ilike', self),('contribution_code_id.code', 'ilike', self)]" />
                     <separator />

--- a/union_school_position/models/position.py
+++ b/union_school_position/models/position.py
@@ -46,7 +46,7 @@ class Position(models.Model):
     import_name = fields.Char(string="Import Name")
     import_vat = fields.Char(string="Import VAT")
 
-    uid = fields.Char(related="affiliate_id.uid", store=False)
+    uid = fields.Integer(related="affiliate_id.uid", store=False)
     personal_id = fields.Char(related="affiliate_id.personal_id", store=False)
     dedication = fields.Char(
         related="type_id.dedication",
@@ -141,19 +141,27 @@ class Position(models.Model):
                 if not vals.get("affiliate_id"):
                     affiliate = False
                     if vals.get("import_uid"):
-                        affiliate = self.env["affiliation.affiliate"].search(
-                            [("uid", "=", vals["import_uid"])], limit=1
-                        )
+                        try:
+                            uid_int = int(vals["import_uid"])
+                        except (TypeError, ValueError):
+                            raise ValidationError(_("El campo ID debe contener un número entero válido."))
+                        affiliate = self.env["affiliation.affiliate"].search([("uid", "=", uid_int)], limit=1)
 
                     if affiliate:
                         vals["affiliate_id"] = affiliate.id
                     else:
                         conf = self.env["affiliation.affiliation_configuration"].browse(1)
                         if conf.create_user_from_position:
-                            new_uid = vals.get("import_uid")
                             import_name = vals.get("import_name")
 
-                            if not new_uid or not import_name:
+                            try:
+                                uid_int = int(vals.get("import_uid"))
+                            except (TypeError, ValueError):
+                                raise ValidationError(_("El campo ID debe contener un número entero válido."))
+                            if uid_int <= 0:
+                                raise ValidationError(_("El campo ID debe ser un número positivo."))
+
+                            if not import_name:
                                 error_msg = _(
                                     "Cannot create affiliate for position import."
                                     " Missing import_name or ID (import_uid)."
@@ -161,14 +169,9 @@ class Position(models.Model):
                                 )
                                 raise ValidationError(error_msg)
 
-                            if not str(new_uid).isdigit():
-                                raise ValidationError(_("El campo ID debe contener únicamente números."))
-                            if str(new_uid)[0] == "0":
-                                raise ValidationError(_("El campo ID no puede comenzar con cero."))
-
                             new_affiliate_vals = {
                                 "state": "new",
-                                "uid": new_uid,
+                                "uid": uid_int,
                                 "name": import_name,
                             }
 

--- a/union_school_position/models/position.py
+++ b/union_school_position/models/position.py
@@ -143,8 +143,8 @@ class Position(models.Model):
                     if vals.get("import_uid"):
                         try:
                             uid_int = int(vals["import_uid"])
-                        except (TypeError, ValueError):
-                            raise ValidationError(_("El campo ID debe contener un número entero válido."))
+                        except (TypeError, ValueError) as exc:
+                            raise ValidationError(_("El campo ID debe contener un número entero válido.")) from exc
                         affiliate = self.env["affiliation.affiliate"].search([("uid", "=", uid_int)], limit=1)
 
                     if affiliate:
@@ -156,8 +156,8 @@ class Position(models.Model):
 
                             try:
                                 uid_int = int(vals.get("import_uid"))
-                            except (TypeError, ValueError):
-                                raise ValidationError(_("El campo ID debe contener un número entero válido."))
+                            except (TypeError, ValueError) as exc:
+                                raise ValidationError(_("El campo ID debe contener un número entero válido.")) from exc
                             if uid_int <= 0:
                                 raise ValidationError(_("El campo ID debe ser un número positivo."))
 

--- a/union_school_position/tests/test_affiliate_extension.py
+++ b/union_school_position/tests/test_affiliate_extension.py
@@ -12,7 +12,7 @@ class TestAffiliateExtension(TransactionCase):
         cls.affiliate = (
             cls.env["affiliation.affiliate"]
             .sudo()
-            .create({"uid": "40000001", "name": "Extension Test Affiliate", "state": "new"})
+            .create({"uid": 40000001, "name": "Extension Test Affiliate", "state": "new"})
         )
         cls.pos_type = cls.env["school_position.type"].create(
             {

--- a/union_school_position/tests/test_position.py
+++ b/union_school_position/tests/test_position.py
@@ -14,7 +14,7 @@ class TestPosition(TransactionCase):
         cls.affiliate = (
             cls.env["affiliation.affiliate"]
             .sudo()
-            .create({"uid": "20000001", "name": "Position Test Affiliate", "state": "new"})
+            .create({"uid": 20000001, "name": "Position Test Affiliate", "state": "new"})
         )
         cls.pos_type = cls.env["school_position.type"].create(
             {"code": "TST", "name": "Test Type", "in_hours": True, "dedication": "FT"}
@@ -194,7 +194,7 @@ class TestPosition(TransactionCase):
             )
         )
         self.assertTrue(pos.affiliate_id)
-        self.assertEqual(pos.affiliate_id.uid, "30000003")
+        self.assertEqual(pos.affiliate_id.uid, 30000003)
 
         # Cleanup
         config.write({"create_user_from_position": False})

--- a/union_school_position/tests/test_security.py
+++ b/union_school_position/tests/test_security.py
@@ -1,7 +1,9 @@
 from odoo.exceptions import AccessError, UserError
 from odoo.tests import TransactionCase, tagged
 
-grp = lambda env, x: env.ref(x).id
+
+def grp(env, x):
+    return env.ref(x).id
 
 
 @tagged("post_install", "security", "union")

--- a/union_school_position/tests/test_security.py
+++ b/union_school_position/tests/test_security.py
@@ -14,7 +14,7 @@ class TestSchoolPositionSecurity(TransactionCase):
         cls.Position = cls.env["school_position.position"]
         cls.Affiliate = cls.env["affiliation.affiliate"]
         cls.affiliate_type = cls.env["affiliation.affiliate_type"].create({"name": "Sec PType", "enabled": True})
-        cls.aff = cls.Affiliate.sudo().create({"uid": "33333333", "name": "Sec Aff P", "state": "new"})
+        cls.aff = cls.Affiliate.sudo().create({"uid": 33333333, "name": "Sec Aff P", "state": "new"})
         cls.pos_type = cls.env["school_position.type"].create(
             {"code": "SECT", "name": "Sec PosType", "in_hours": True, "dedication": "FT"}
         )

--- a/union_school_position/views/position_views.xml
+++ b/union_school_position/views/position_views.xml
@@ -58,7 +58,7 @@
             <field name="arch" type="xml">
                 <search string="Position filters">
                     <field name="affiliate_id"
-                        filter_domain="['|','|',('affiliate_id.name', 'ilike', self),('affiliate_id.uid', 'ilike', self),('affiliate_id.personal_id', 'ilike', self)]" />
+                        filter_domain="['|','|',('affiliate_id.name', 'ilike', self),('affiliate_id.uid', '=', self),('affiliate_id.personal_id', 'ilike', self)]" />
                     <field name="type_id"
                         filter_domain="['|',('type_id.name', 'ilike', self),('type_id.code', 'ilike', self)]" />
                     <field name="workplace_id"


### PR DESCRIPTION
- union_affiliation: uid field Char→Integer, drop _check_uid Python
  constraint (isdigit/leading-zero resolved by type), add SQL CHECK
  (uid > 0), rework _name_search to use = for numeric input,
  remove ilike filter_domain from search view, bump 19.0.1.1.0→19.0.1.2.0,
  add migrations/19.0.1.2.0/pre-migrate.py
- union_contribution: related uid Char→Integer, import flow uses int()
  cast, search view ilike→=
- union_school_position: related uid Char→Integer, import flow uses
  int() cast, search view ilike→=
- union_benefit_request: affiliate_uid Char→Integer (stored computed),
  import flow uses int() cast
- all modules: update tests (string→int fixtures, replace isdigit/
  leading-zero tests with uid>0 test)